### PR TITLE
Fix primary key of Key

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ REQUIRES = [
     # http://initd.org/psycopg/docs/install.html#binary-install-from-pypi
     'psycopg2-binary',
     'py',
-    'PyYAML',
     'SQLAlchemy',
     'stringcase'
 ]

--- a/src/minerva_db/sql/models/key.py
+++ b/src/minerva_db/sql/models/key.py
@@ -7,7 +7,8 @@ from .import_ import Import
 
 class Key(Base):
     key = Column(String(1024), primary_key=True, nullable=False)
-    import_uuid = Column(String(36), ForeignKey(Import.uuid), nullable=False)
+    import_uuid = Column(String(36), ForeignKey(Import.uuid), primary_key=True,
+                         nullable=False)
     bfu_uuid = Column(String(36), ForeignKey(BFU.uuid))
 
     import_ = relationship('Import', back_populates='keys')

--- a/tests/sql/resource.py
+++ b/tests/sql/resource.py
@@ -181,6 +181,7 @@ class TestBFU():
             user_granted_read_hierarchy['bfu_uuid']
         )
 
+
 class TestImage():
 
     def test_create_image(self, client, session, db_bfu):


### PR DESCRIPTION
Primary key of `Key` should be composite of `key` with `import_uuid` or otherwise the same filename uploaded in two imports will fail.