### PR TITLE
Fix default ownership of a group by creating user

### DIFF
--- a/src/minerva_db/sql/api/client.py
+++ b/src/minerva_db/sql/api/client.py
@@ -44,7 +44,7 @@ class Client():
 
         user = self.session.query(User).filter(User.uuid == user_uuid).one()
         group = Group(uuid, name)
-        membership = Membership(group, user)
+        membership = Membership(group, user, 'Owner')
         self.session.add(group)
         self.session.add(membership)
         self.session.commit()

--- a/src/minerva_db/sql/models/membership.py
+++ b/src/minerva_db/sql/models/membership.py
@@ -16,7 +16,7 @@ class Membership(Base):
     group = relationship('Group', back_populates='memberships')
     user = relationship('User', back_populates='memberships')
 
-    def __init__(self, group=None, user=None, membership_type='Member'):
+    def __init__(self, group, user, membership_type='Member'):
         self.group = group
         self.user = user
         self.membership_type = membership_type

--- a/tests/sql/subjects.py
+++ b/tests/sql/subjects.py
@@ -42,6 +42,12 @@ class TestGroup():
         assert d == client.create_group(user_uuid=db_user.uuid, **d)
         assert d == sa_obj_to_dict(session.query(Group).one(), keys)
 
+    def test_create_group_owner(self, client, session, db_user):
+        keys = ('uuid', 'name')
+        d = sa_obj_to_dict(GroupFactory(), keys)
+        client.create_group(user_uuid=db_user.uuid, **d)
+        assert session.query(Membership).one().membership_type == 'Owner'
+
     @pytest.mark.parametrize('duplicate_key', ['uuid', 'name'])
     def test_create_group_duplicate(self, client, db_user, duplicate_key):
         keys = ('uuid', 'name')


### PR DESCRIPTION
By default, the user creating a group was becoming a group 'Member' instead of an 'Owner'. This changes that default.